### PR TITLE
Fixing php notice

### DIFF
--- a/social-counts.php
+++ b/social-counts.php
@@ -63,7 +63,8 @@ function update_social_share_count( int $post_id ) {
 			continue;
 		}
 		foreach ( $counts as $key => $value ) {
-			$all_counts[ $key ] += $value;
+			$count = isset ( $all_counts[ $key ] ) ? $all_counts[ $key ] : 0;
+			$all_counts[ $key ] = $count + $value;
 		}
 	}
 	update_post_meta( $post_id, 'hm_share_counts', $all_counts );

--- a/social-counts.php
+++ b/social-counts.php
@@ -63,7 +63,7 @@ function update_social_share_count( int $post_id ) {
 			continue;
 		}
 		foreach ( $counts as $key => $value ) {
-			$count = isset ( $all_counts[ $key ] ) ? $all_counts[ $key ] : 0;
+			$count = isset( $all_counts[ $key ] ) ? $all_counts[ $key ] : 0;
 			$all_counts[ $key ] = $count + $value;
 		}
 	}


### PR DESCRIPTION
Fixing PHP notices for undefined index. The first iteration of this foreach loop the `$all_counts` does not have an array index of `$key` so using the operator `+=` throws the notice.

```
Notice: Undefined index: StumbleUpon in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Reddit in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Facebook in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Delicious in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: GooglePlusOne in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Buzz in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Twitter in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Diggs in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: Pinterest in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: LinkedIn in .../plugins/social-counts/social-counts.php on line 66
Notice: Undefined index: total in .../plugins/social-counts/social-counts.php on line 66
```